### PR TITLE
Updated joining instructions for Winter 2024

### DIFF
--- a/config/join.md
+++ b/config/join.md
@@ -2,70 +2,8 @@
 
 Thank you for your interest in joining MDST! We're super excited to get you started on the process for joining the club.
 
-### Step 1: Sign up for our mailing list
+Our mailing list is going to be the fastest way for us to reach you with the latest information on how to join, mass meetings, and other onboarding events. Fill out the [interest form](https://forms.gle/pcpfjMwrXobyvn9N9) linked below to be added to our mailing list.
 
-Our mailing list is going to be the fastest way for us to reach you with the latest information on how to join, mass meetings, and other onboarding events. Fill out the [interest form](https://forms.gle/B5TyHZHL44BcoKNX6) linked below to be added to our mailing list.
+<p className="md-button-wrapper"><a className="md-button" href="https://forms.gle/pcpfjMwrXobyvn9N9"> Interest Form</a></p>
 
-<p className="md-button-wrapper"><a className="md-button" href="https://forms.gle/B5TyHZHL44BcoKNX6"> Interest Form</a></p>
-
-<hr>
-
-### Step 2: Attend our Mass Meetings
-
-MDST will host **two mass meetings** over the first 2 weeks of the Fall 2023 semester. At these meetings, we will discuss alot more about our club, what we do, and how to join. You'll also have the opportunity to ask questions you may have about joining.
-
-- **Mass Meeting 1**: August 31th, 6:30 - 7:30. East Hall 1360
-- **Mass Meeting 2**: September 4th, 4:30 - 5:30 PM. Michigan Union (Wolverine Room)
-- **Our slides and recordings can be find below**
-
-Both mass meetings will cover the same content and will be recorded if you are unable to attend.
-Mass Meetings are for informational purposes. **We do not take attendance, and they are not part of the application process.**
-
-You can find our mass meeting [slides](https://docs.google.com/presentation/d/1eb_zenR8Zj8UAUyYdg0B27pB9w-9lVszJxb5Lzxec8E/edit?usp=sharing) and [recording](https://drive.google.com/file/d/1lztjqm4FDRo1RKCBERAQxN48msrd6CXq/view?usp=drive_link) (you will need to be logged into your U-M account).
-
-<hr>
-
-### Step 3: Complete Tutorial Checkpoints
-
-New members are required to **complete two tutorials** giving an introduction to data science and programming in Python. The purpose of these tutorials is to make sure that all of our members, despite their background, is able to equally contribute to MDST projects.
-
-<div className="callout font-normal">
-    The tutorials for Fall 2023 are now published in the tutorial GitHub [repository](https://github.com/MichiganDataScienceTeam/2023-Tutorials). The repository contains all the materials you need as well as information about the support we provide. We also recommend reading through our [FAQ](#FAQ) for any questions you may have in the meantime.
-</div>
-
-#### Tutorial Format
-
-The format of each tutorial includes:
-
-- A Jupyter notebook which walks you through the relevant content for that tutorial. Never heard of a Jupyter notebook before? Check out the [Jupyter documentation](https://docs.jupyter.org/en/latest/) to learn more.
-- A **checkpoint** to check your understanding of the tutorial content. <span className="highlight">You must correctly complete and submit this checkpoint in order to join MDST</span>.
-
-<div className="callout">
-    In addition to the main 2 tutorials, there is an **_optional_ challenge** component which you can complete to showcase your skills in more advanced data science concepts such as machine learning. Your performance on these challenge sections will be used to determine your placement into more difficult projects.
-</div>
-
-If you feel frustrated at any point when working through the tutorials, know it is normal (the majority of active MDST members have been in your exact spot before and know how annoying working with some of this technology could be). For this reason, our education committee hosts **office hours** throughout the onboarding process so you can ask questions and get help on what you're stuck on. **See our [events calendar](https://calendar.google.com/calendar/embed?src=c_22ca0c151585760442cad5796fb91bd18b7db11d813e9143e38549aadce65afe%40group.calendar.google.com&ctz=America%2FNew_York) for office hour times and locations.**
-
-In addition, you should post any question on our [Piazza forum](https://piazza.com/umich/fall2023/mdst101). You may also email Casper at casperg@umich.edu. Please only use the email address for personal questions; all questions of a technical nature should be posted to Piazza.
-
-<hr>
-
-### Step 4: Attend our Project Exploration Fair
-
-Join us on **September 10th, 4:30 - 6:00 PM @ CCCB 2460** to learn about all the projects we will run this semester and directly ask our project leaders any questions you have about the specific project goals and motivations.
-
-This event is optional but highly encouraged.
-
-<hr>
-
-### Step 5: Submit Checkpoints and Sign-up For Projects
-
-<p className="md-button-wrapper"><a className="md-button" href="https://forms.gle/rbAPMckFMegE6fAM6"> Project Sign-up Form</a></p>
-
-We have released the project sign-up form. You can specify your project preferences, along with a link to the GitHub repository containing all the completed checkpoints plus the optional challenges (if attempted). If you've never worked with Git and GitHub before, check out our [Git Version Control Guide](https://docs.google.com/document/d/1pq42R2xr_yoyhyzWE0ugReHgEKgwLdjrJR4mT3_CQEo/edit?usp=sharing).
-
-- <span className="highlight">If your checkpoints are incomplete, then you will not be allowed to join MDST for that semester.</span> In such circumstance, you may attempt the checkpoints again the next semester and resubmit.
-- Our education committee will evaluate your submission for your strength with Python programming and data science library usage. New members with greater skills in these areas are more likely to be placed into tougher projects.
-- Most people tend to get their top project choices, so don't worry!
-
-The project signup form will be due **September 14th, 11:59 PM**, after which we will no longer accept sign-ups for projects for the Fall 2023 semester. You will receive notice of your project assignment by **September 17th**, at which point we start working on our projects!
+Stay tuned for steps for joining MDST in Winter 2024!

--- a/config/timeline.json
+++ b/config/timeline.json
@@ -1,6 +1,6 @@
 {
-  "show_on_homepage": true,
-  "title": "Recruiting Timeline",
+  "show_on_homepage": false,
+  "title": "Recruiting Timeline Fall 2023 (OLD)",
   "events": [
     {
       "title": "Festifall Central @ Booth D79",


### PR DESCRIPTION
- Removed timeline for homepage temporarily (will add back later one timeline is finalized)
- Updated _Join_ page to:
    - replace old interest form with new interest form
    - remove old joining instructions for Fall 2023 